### PR TITLE
Modify monster handlebar to account for duplicate attacks

### DIFF
--- a/handlebars/monster_handlebar.hbs
+++ b/handlebars/monster_handlebar.hbs
@@ -75,8 +75,8 @@ abilities_mid:
 attacks:
   - name: ""
 {{#each items}}{{#if (eq type "melee")}}
-  - name: "{{#if this.isRanged}}Ranged{{else}}Melee{{/if}}"
-    desc: "`pf2:1` {{this.name}} {{numberFormat system.bonus.value sign=true}} ({{#each system.traits.value}}{{lower (me-trait this)}}{{ifThen @last "" ", "}}{{/each}})\n__Damage__ {{#each system.damageRolls}} {{{this.damage}}} {{this.damageType}}{{#if ../system.attackEffects.value}} plus {{../system.attackEffects.value}}{{/if}}{{/each}}"
+  - name: "**{{#if this.isRanged}}Ranged{{else}}Melee{{/if}}** `pf2:1` {{this.name}}"
+    desc: "{{numberFormat system.bonus.value sign=true}} ({{#each system.traits.value}}{{lower (me-trait this)}}{{ifThen @last "" ", "}}{{/each}})\n__Damage__ {{#each system.damageRolls}} {{{this.damage}}} {{this.damageType}}{{#if ../system.attackEffects.value}} plus {{../system.attackEffects.value}}{{/if}}{{/each}}"
 {{/if}}{{/each~}}
 {{#each items as |item|}}{{#if (eq item.type "spellcastingEntry")}}
   - name: "{{item.name}}"


### PR DESCRIPTION
Closes https://github.com/MostTornBrain/pf2e-md-exporter/issues/3

This fixes an issue where if you have mutiple Melee attacks, only the last is shown in Obsidian. I suspect this happens because the YAML expects unique names in the list.