### PR TITLE
Support encounters and dt tags

### DIFF
--- a/scripts/export-markdown.js
+++ b/scripts/export-markdown.js
@@ -864,6 +864,14 @@ function setupTurndown() {
           }
         });
 
+        // Definition lists are just simple text otherwise
+        turndownService.addRule('replaceDts', {
+            filter: ['dt'],
+            replacement: function (content) {
+                return '##### ' + content;
+            }
+        });
+
     }
 }
 

--- a/scripts/export-markdown.js
+++ b/scripts/export-markdown.js
@@ -678,7 +678,7 @@ function convertPF2ETags(doc, html) {
     // and turn it into: Dc 20 Thievery Skill Check
     const checkPatternWithDesc = /@Check\[(?:[^\]]*?\|)?type:([^\|\]]+)\|(?:[^\]]*?)dc:(\d+)(?:\|[^\]]*?)?\]\{([^}]*)\}/g;
     markdown = markdown.replace(checkPatternWithDesc, function(match, p1, p2, p3) {
-        return `DC ${p2} ${p3}`;
+        return `\`DC ${p2} ${p3}\``;
     });
 
 
@@ -790,7 +790,7 @@ function convertPF2ETags(doc, html) {
     markdown = markdown.replace(checkPattern, function(match, p1, p2) {
                                                     // Convert sluggified p1 to more friendly label
                                                     p1 = p1.split("-").map(word=>word.slice(0,1).toUpperCase()+word.slice(1)).join(" ");
-                                                    return `DC ${p2} ${p1} check`;
+                                                    return `\`DC ${p2} ${p1} check\``;
                                                 });
 
     // Convert @Check for "basic save" to plain text
@@ -804,10 +804,10 @@ function convertPF2ETags(doc, html) {
                                                     p1 = p1.split("-").map(word=>word.slice(0,1).toUpperCase()+word.slice(1)).join(" ");
 
                                                     if (basic) {
-                                                        return `basic ${p1} check`;
+                                                        return `\`basic ${p1} check\``;
                                                     } else {
-                                                        return `${p1} check`;
-                                                    }   
+                                                        return `\`${p1} check\``;
+                                                    }
                                                 });
 
     return markdown;
@@ -886,10 +886,11 @@ async function convertHtmlAsync(doc, html) {
 
         // The conversion "escapes" the "[[...]]" markers, so we have to remove those markers afterwards
         markdown = turndownService.turndown(markdown).replaceAll("\\[\\[","[[").replaceAll("\\]\\]","]]");
-        
-        // Correct any escaped underscores that resulted from the turndown service
+
+        // Correct any escaped underscores and backticks that resulted from the turndown service
         markdown = markdown.replaceAll("\\_", "_");
-        
+        markdown = markdown.replaceAll("\\`", "`");
+
         // Now convert file references
         const filepattern = /!\[([^\]]*)\]\(([^)]*)\)/g;
         markdown = markdown.replaceAll(filepattern, replaceLinkedFile);
@@ -949,10 +950,11 @@ export function convertHtml(doc, html) {
 
         // The conversion "escapes" the "[[...]]" markers, so we have to remove those markers afterwards
         markdown = turndownService.turndown(markdown).replaceAll("\\[\\[","[[").replaceAll("\\]\\]","]]");
-        
-        // Correct any escaped underscores that resulted from the turndown service
+
+        // Correct any escaped underscores and backticks that resulted from the turndown service
         markdown = markdown.replaceAll("\\_", "_");
-        
+        markdown = markdown.replaceAll("\\`", "`");
+
         // Now convert file references
         const filepattern = /!\[([^\]]*)\]\(([^)]*)\)/g;
         markdown = markdown.replaceAll(filepattern, replaceLinkedFile);

--- a/scripts/lib/turndown.js
+++ b/scripts/lib/turndown.js
@@ -94,9 +94,11 @@ export var TurndownService = (function () {
         callout_type = "cite";
       } else if (pclass.includes('encounter')) {
         callout_type = "danger";
+      } else if (pclass.includes('investigation')) {
+        callout_type = "question";
       } else if (pclass.includes('treasure')) {
         callout_type = "example";
-      }  else if (pclass.includes('creation') || pclass.includes('fvtt')) {
+      }  else if (pclass.includes('creation') || pclass.includes('fvtt') || pclass.includes('compartment')) {
         callout_type = "tip";
       } else if (!pclass.includes('info')) {
         console.log("Unknown box text: ", pclass);


### PR DESCRIPTION
Hi, there were missing formatting for some blocks that are used in Journals in Abomination Vaults. 

Before
<img width="843" alt="Screenshot 2025-04-26 at 22 26 33" src="https://github.com/user-attachments/assets/70e4bbdd-c11e-44b8-b6e2-fd7f03327a57" />
<img width="817" alt="Screenshot 2025-04-26 at 22 26 00" src="https://github.com/user-attachments/assets/c7ad34bb-715b-4a5a-a2a9-a58c2c78e90b" />
<img width="811" alt="Screenshot 2025-04-26 at 22 25 55" src="https://github.com/user-attachments/assets/4cf445f2-0828-4689-8376-b0be98e7ee8b" />


After

<img width="807" alt="Screenshot 2025-04-26 at 22 22 59" src="https://github.com/user-attachments/assets/45256b41-dc8d-4b53-b92d-c445ddfe7e49" />
<img width="807" alt="Screenshot 2025-04-26 at 22 22 51" src="https://github.com/user-attachments/assets/d8b6ff4c-f58d-43c6-91c5-024a0f1a4816" />
<img width="810" alt="Screenshot 2025-04-26 at 22 22 45" src="https://github.com/user-attachments/assets/d37ae44a-e9be-428d-a90b-279c68cd4d16" />

