### PR TITLE
Update compatibility version range in module.json

### DIFF
--- a/module.json
+++ b/module.json
@@ -5,9 +5,9 @@
   "version": "#{VERSION}#",
   "library": "false",
   "compatibility": {
-    "minimum": "13.336",
-    "maximum": "13.999",
-    "verified": "13.344"
+    "minimum": "13",
+    "maximum": "14",
+    "verified": "14.364"
   },
   "authors": [
     {


### PR DESCRIPTION
I have verified that the export still works on V14 without any further changes when exporting the Monster Core 2 bestiary to Obsidian. 

All actors are imported with the correct frontmatter, and associated images, and display correctly when using the Obsidian plugin: Fantasy Statblocks.